### PR TITLE
Fix NullPointException in LoggingAspect AOP class

### DIFF
--- a/src/main/java/nstarlike/jcw/aop/LoggingAspect.java
+++ b/src/main/java/nstarlike/jcw/aop/LoggingAspect.java
@@ -1,7 +1,6 @@
 package nstarlike.jcw.aop;
 
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
@@ -21,7 +20,7 @@ public class LoggingAspect {
 		
 		int size = names.length;
 		for(int i=0; i<size; i++) {
-			logger.debug(names[i] + " => " + args[i].toString());
+			logger.debug(names[i] + " => " + args[i]);
 		}
 	}
 }


### PR DESCRIPTION
Remove toString method in log statement in LogginAspect AOP class.
If an argument is null, null string will be logged.